### PR TITLE
Release v1.0.24

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,12 +18,12 @@ When you make a contribution to the project, you agree:
 
 ## Prerequisites
 
-* [ ] Have you [searched for duplicates](https://github.com/pmonks/wcwidth/issues?utf8=%E2%9C%93&q=)?  A simple search for exception error messages or a summary of the unexpected behaviour should suffice.
+* [ ] Have you [searched for duplicates](https://github.com/pmonks/clj-wcwidth/issues?utf8=%E2%9C%93&q=)?  A simple search for exception error messages or a summary of the unexpected behaviour should suffice.
 * [ ] Are you sure this is a bug or missing capability?
 
 ## Raising an Issue
 
-* Create your issue [here](https://github.com/pmonks/wcwidth/issues/new).
+* Create your issue [here](https://github.com/pmonks/clj-wcwidth/issues/new).
 * New issues contain two templates in the description: bug report and enhancement request. Please pick the most appropriate for your issue.
 * Please use [Markdown formatting](https://help.github.com/categories/writing-on-github/) liberally to assist in readability.
   * [Code fences](https://help.github.com/articles/creating-and-highlighting-code-blocks/) for exception stack traces and log entries, for example, massively improve readability.

--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+

--- a/LICENSE.spdx
+++ b/LICENSE.spdx
@@ -1,7 +1,7 @@
 SPDXVersion: SPDX-2.1
 DataLicense: CC0-1.0
 Creator: Peter Monks
-PackageName: com.github.pmonks/spinner
+PackageName: com.github.pmonks/clj-wcwidth
 PackageOriginator: Peter Monks
-PackageHomePage: https://github.com/pmonks/spinner
+PackageHomePage: https://github.com/pmonks/clj-wcwidth
 PackageLicenseDeclared: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ This library provides a pure, zero-dependency Clojure implementation of the rule
 
 ## Installation
 
-`wcwidth` is available as a Maven artifact from [Clojars](https://clojars.org/com.github.pmonks/wcwidth).
+`clj-wcwidth` is available as a Maven artifact from [Clojars](https://clojars.org/com.github.pmonks/clj-wcwidth).
 
 ### Trying it Out
 
 #### Clojure CLI
 
 ```shell
-$ clojure -Sdeps '{:deps {com.github.pmonks/wcwidth {:mvn/version "#.#.#"}}}'  # Where #.#.# is replaced with an actual version number (see badge above)
+$ clojure -Sdeps '{:deps {com.github.pmonks/clj-wcwidth {:mvn/version "#.#.#"}}}'  # Where #.#.# is replaced with an actual version number (see badge above)
 ```
 
 #### Leiningen
 
 ```shell
-$ lein try com.github.pmonks/wcwidth
+$ lein try com.github.pmonks/clj-wcwidth
 ```
 
 #### Simple REPL Session

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | [**main**](https://github.com/pmonks/clj-wcwidth/tree/main) | [![CI](https://github.com/pmonks/clj-wcwidth/workflows/CI/badge.svg?branch=main)](https://github.com/pmonks/clj-wcwidth/actions?query=workflow%3ACI+branch%3Amain) | [![Dependencies](https://github.com/pmonks/clj-wcwidth/workflows/dependencies/badge.svg?branch=main)](https://github.com/pmonks/clj-wcwidth/actions?query=workflow%3Adependencies+branch%3Amain) |
 | [**dev**](https://github.com/pmonks/clj-wcwidth/tree/dev) | [![CI](https://github.com/pmonks/clj-wcwidth/workflows/CI/badge.svg?branch=dev)](https://github.com/pmonks/clj-wcwidth/actions?query=workflow%3ACI+branch%3Adev) | [![Dependencies](https://github.com/pmonks/clj-wcwidth/workflows/dependencies/badge.svg?branch=dev)](https://github.com/pmonks/clj-wcwidth/actions?query=workflow%3Adependencies+branch%3Adev) |
 
-[![Latest Version](https://img.shields.io/clojars/v/com.github.pmonks/wcwidth)](https://clojars.org/com.github.pmonks/wcwidth/) [![Open Issues](https://img.shields.io/github/issues/pmonks/wcwidth.svg)](https://github.com/pmonks/clj-wcwidth/issues) [![License](https://img.shields.io/github/license/pmonks/wcwidth.svg)](https://github.com/pmonks/clj-wcwidth/blob/main/LICENSE)
+[![Latest Version](https://img.shields.io/clojars/v/com.github.pmonks/clj-wcwidth)](https://clojars.org/com.github.pmonks/clj-wcwidth/) [![Open Issues](https://img.shields.io/github/issues/pmonks/clj-wcwidth.svg)](https://github.com/pmonks/clj-wcwidth/issues) [![License](https://img.shields.io/github/license/pmonks/clj-wcwidth.svg)](https://github.com/pmonks/clj-wcwidth/blob/main/LICENSE)
 
 # wcwidth
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,6 @@ $ lein try com.github.pmonks/clj-wcwidth
 (wcw/wcwidth 0x1F921)  ; 🤡
 ; ==> 2   (double width)
 
-
-  
 (wcw/wcswidth "hello, 🤡")
 ; ==> 12
 (wcw/wcswidth (str "hello, world" (wcw/codepoint-to-string 0x0084)))   ; non-printing char

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 [![Latest Version](https://img.shields.io/clojars/v/com.github.pmonks/clj-wcwidth)](https://clojars.org/com.github.pmonks/clj-wcwidth/) [![Open Issues](https://img.shields.io/github/issues/pmonks/clj-wcwidth.svg)](https://github.com/pmonks/clj-wcwidth/issues) [![License](https://img.shields.io/github/license/pmonks/clj-wcwidth.svg)](https://github.com/pmonks/clj-wcwidth/blob/main/LICENSE)
 
-# wcwidth
+# clj-wcwidth
 
 Pure Clojure implementations of the [`wcwidth`](https://man7.org/linux/man-pages/man3/wcwidth.3.html) and [`wcswidth`](https://man7.org/linux/man-pages/man3/wcswidth.3.html) POSIX functions (plus some other useful Unicode functions).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # wcwidth
 
-Pure Clojure implementations of the [`wcwidth`](https://man7.org/linux/man-pages/man3/wcwidth.3.html) and [`wcswidth`](https://man7.org/linux/man-pages/man3/wcswidth.3.html) POSIX functions.
+Pure Clojure implementations of the [`wcwidth`](https://man7.org/linux/man-pages/man3/wcwidth.3.html) and [`wcswidth`](https://man7.org/linux/man-pages/man3/wcswidth.3.html) POSIX functions (plus some other useful Unicode functions).
 
 ## Why?
 
@@ -39,16 +39,25 @@ $ lein try com.github.pmonks/wcwidth
 (require '[wcwidth.api :as wcw] :reload-all)
 
 (wcw/wcwidth \A)
+; ==> 1
 (wcw/wcwidth \©)
+; ==> 1
+(wcw/wcwidth 0x0000)   ; ASCII NUL
+; ==> 0   (nul)
 (wcw/wcwidth 0x001B)   ; ASCII ESC
+; ==> -1  (non-printing)
 (wcw/wcwidth 0x1F921)  ; 🤡
+; ==> 2   (double width)
 
-(wcw/wcwidth "hello, world")
-(wcw/wcwidth "hello, 🤡")
-(wcw/wcwidth (str "hello, world" (wcw/codepoint-to-string 0x0084)))   ; non-printing char
 
-; Showing the difference between the POSIX wcswidth behaviour and the (more useful for Clojure, but non-POSIX) wcswidth2 behaviour
-(wcw/wcwidth2 (str "hello, world" (wcw/codepoint-to-string 0x0084)))   ; non-printing char
+  
+(wcw/wcswidth "hello, 🤡")
+; ==> 12
+(wcw/wcswidth (str "hello, world" (wcw/codepoint-to-string 0x0084)))   ; non-printing char
+; ==> -1  (due to non-printing character)
+
+(wcw/wcswidth2 (str "hello, world" (wcw/codepoint-to-string 0x0084)))   ; non-printing char
+; ==> 12  (showing the difference between the POSIX wcswidth behaviour and the more useful for Clojure, but non-POSIX, wcswidth2 behaviour)
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Pure Clojure implementations of the [`wcwidth`](https://man7.org/linux/man-pages
 
 When printing Unicode characters to a fixed-width display device (e.g. a terminal), every Unicode code point has a well-defined "column width".  This was originally standardised in [Unicode Technical Report #11](https://unicode.org/reports/tr11-5/), and implemented as the POSIX functions `wcwidth` and `wcswidth` soon after.
 
-Java doesn't provide these functions however, so applications that need to know these widths (e.g. for terminal screen formatting purposes) are left to their own devices.  While there are Java libraries that have implemented this themselves (notably [JLine](https://github.com/jline/jline3/blob/master/terminal/src/main/java/org/jline/utils/WCWidth.java)), pulling in a large dependency when one only uses a very small part of it is sometimes overkill.   This library provides a pure, zero-dependency Clojure implementation of the rules described in UTR-11 (and updated for recent Unicode versions), to avoid having to do that.
+Java doesn't provide these functions however, so applications that need to know these widths (e.g. for terminal screen formatting purposes) are left to their own devices.  While there are Java libraries that have implemented this themselves (notably [JLine](https://github.com/jline/jline3/blob/master/terminal/src/main/java/org/jline/utils/WCWidth.java)), pulling in a large dependency when one only uses a very small part of it is sometimes overkill.
+
+This library provides a pure, zero-dependency Clojure implementation of the rules described in UTR-11 (and updated for recent Unicode versions), to avoid having to do that.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 | | | |
 |---:|:---:|:---:|
-| [**main**](https://github.com/pmonks/wcwidth/tree/main) | [![CI](https://github.com/pmonks/wcwidth/workflows/CI/badge.svg?branch=main)](https://github.com/pmonks/wcwidth/actions?query=workflow%3ACI+branch%3Amain) | [![Dependencies](https://github.com/pmonks/wcwidth/workflows/dependencies/badge.svg?branch=main)](https://github.com/pmonks/wcwidth/actions?query=workflow%3Adependencies+branch%3Amain) |
-| [**dev**](https://github.com/pmonks/wcwidth/tree/dev) | [![CI](https://github.com/pmonks/wcwidth/workflows/CI/badge.svg?branch=dev)](https://github.com/pmonks/wcwidth/actions?query=workflow%3ACI+branch%3Adev) | [![Dependencies](https://github.com/pmonks/wcwidth/workflows/dependencies/badge.svg?branch=dev)](https://github.com/pmonks/wcwidth/actions?query=workflow%3Adependencies+branch%3Adev) |
+| [**main**](https://github.com/pmonks/clj-wcwidth/tree/main) | [![CI](https://github.com/pmonks/clj-wcwidth/workflows/CI/badge.svg?branch=main)](https://github.com/pmonks/clj-wcwidth/actions?query=workflow%3ACI+branch%3Amain) | [![Dependencies](https://github.com/pmonks/clj-wcwidth/workflows/dependencies/badge.svg?branch=main)](https://github.com/pmonks/clj-wcwidth/actions?query=workflow%3Adependencies+branch%3Amain) |
+| [**dev**](https://github.com/pmonks/clj-wcwidth/tree/dev) | [![CI](https://github.com/pmonks/clj-wcwidth/workflows/CI/badge.svg?branch=dev)](https://github.com/pmonks/clj-wcwidth/actions?query=workflow%3ACI+branch%3Adev) | [![Dependencies](https://github.com/pmonks/clj-wcwidth/workflows/dependencies/badge.svg?branch=dev)](https://github.com/pmonks/clj-wcwidth/actions?query=workflow%3Adependencies+branch%3Adev) |
 
-[![Latest Version](https://img.shields.io/clojars/v/com.github.pmonks/wcwidth)](https://clojars.org/com.github.pmonks/wcwidth/) [![Open Issues](https://img.shields.io/github/issues/pmonks/wcwidth.svg)](https://github.com/pmonks/wcwidth/issues) [![License](https://img.shields.io/github/license/pmonks/wcwidth.svg)](https://github.com/pmonks/wcwidth/blob/main/LICENSE)
+[![Latest Version](https://img.shields.io/clojars/v/com.github.pmonks/wcwidth)](https://clojars.org/com.github.pmonks/wcwidth/) [![Open Issues](https://img.shields.io/github/issues/pmonks/wcwidth.svg)](https://github.com/pmonks/clj-wcwidth/issues) [![License](https://img.shields.io/github/license/pmonks/wcwidth.svg)](https://github.com/pmonks/clj-wcwidth/blob/main/LICENSE)
 
 # wcwidth
 
@@ -70,15 +70,15 @@ Require it in your application:
 
 ### API Documentation
 
-[API documentation is available here](https://pmonks.github.io/wcwidth/).  [The unit tests](https://github.com/pmonks/wcwidth/blob/main/test/wcwidth/api_test.clj) provide comprehensive usage examples.
+[API documentation is available here](https://pmonks.github.io/clj-wcwidth/).  [The unit tests](https://github.com/pmonks/clj-wcwidth/blob/main/test/wcwidth/api_test.clj) provide comprehensive usage examples.
 
 ## Contributor Information
 
-[Contributing Guidelines](https://github.com/pmonks/wcwidth/blob/main/.github/CONTRIBUTING.md)
+[Contributing Guidelines](https://github.com/pmonks/clj-wcwidth/blob/main/.github/CONTRIBUTING.md)
 
-[Bug Tracker](https://github.com/pmonks/wcwidth/issues)
+[Bug Tracker](https://github.com/pmonks/clj-wcwidth/issues)
 
-[Code of Conduct](https://github.com/pmonks/wcwidth/blob/main/.github/CODE_OF_CONDUCT.md)
+[Code of Conduct](https://github.com/pmonks/clj-wcwidth/blob/main/.github/CODE_OF_CONDUCT.md)
 
 ### Developer Workflow
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ $ lein try com.github.pmonks/clj-wcwidth
 (wcw/wcwidth 0x1F921)  ; 🤡
 ; ==> 2   (double width)
 
-(wcw/wcswidth "hello, 🤡")
+(wcw/wcswidth "hello, world")
 ; ==> 12
+(wcw/wcswidth "hello, 🤡")
+; ==> 9
+
 (wcw/wcswidth (str "hello, world" (wcw/codepoint-to-string 0x0084)))   ; non-printing char
 ; ==> -1  (due to non-printing character)
-
 (wcw/wcswidth2 (str "hello, world" (wcw/codepoint-to-string 0x0084)))   ; non-printing char
 ; ==> 12  (showing the difference between the POSIX wcswidth behaviour and the more useful for Clojure, but non-POSIX, wcswidth2 behaviour)
 ```

--- a/deps.edn
+++ b/deps.edn
@@ -18,6 +18,7 @@
 
 {:aliases
    {:build
-      {:deps       {io.github.seancorfield/build-clj {:git/tag "v0.8.2" :git/sha "0ffdb4c"}
-                    com.github.pmonks/pbr            {:mvn/version "RELEASE"}}
-       :ns-default pbr.build}}}
+      {:deps        {io.github.seancorfield/build-clj {:git/tag "v0.8.2" :git/sha "0ffdb4c"}
+                     com.github.pmonks/pbr            {:mvn/version "RELEASE"}}
+       :ns-default  pbr.build
+       :extra-paths ["src"]}}}  ; To appease codox...

--- a/pbr.clj
+++ b/pbr.clj
@@ -32,5 +32,5 @@
                         :url              "https://github.com/pmonks/clj-wcwidth"
                         :licenses         [:license   {:name "Apache License 2.0" :url "http://www.apache.org/licenses/LICENSE-2.0.html"}]
                         :developers       [:developer {:id "pmonks" :name "Peter Monks" :email "pmonks+wcwidth@gmail.com"}]
-                        :scm              {:url "https://github.com/pmonks/wcwidth" :connection "scm:git:git://github.com/pmonks/wcwidth.git" :developer-connection "scm:git:ssh://git@github.com/pmonks/wcwidth.git"}
-                        :issue-management {:system "github" :url "https://github.com/pmonks/wcwidth/issues"}}))
+                        :scm              {:url "https://github.com/pmonks/clj-wcwidth" :connection "scm:git:git://github.com/pmonks/clj-wcwidth.git" :developer-connection "scm:git:ssh://git@github.com/pmonks/clj-wcwidth.git"}
+                        :issue-management {:system "github" :url "https://github.com/pmonks/clj-wcwidth/issues"}}))

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -22,7 +22,7 @@
 (defn codepoint-to-string
   "Converts any Unicode codepoint to a String.
 
-This is useful because Clojure/Java string literals only support UTF-16 escape sequences, which involves manual construction of all supplementary code points."
+This is useful because Clojure/Java string literals only support UTF-16 escape sequences for code points, which involves manual conversion of all supplementary code points into pairs of escapes."
   [^Integer code-point]
   (when code-point
     (s/join (java.lang.Character/toChars code-point))))

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -71,13 +71,17 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
       :else                 0)))
 
 (defn null?
-  "Is code-point (a character or integer) a null character?"
+  "Is code-point† a null character?
+
+†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (= 0x0000 (int code-point))))
 
 (defn non-printing?
-  "Is code-point (a character or integer) a non-printing character?"
+  "Is code-point† a non-printing character?
+
+†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (let [cp (int code-point)]
@@ -86,13 +90,17 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
                (<  cp 0x00A0))))))
 
 (defn combining?
-  "Is code-point (a character or integer) a combining character?"
+  "Is code-point† a combining character?
+
+†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (>= (java.util.Collections/binarySearch combining-char-ranges [(int code-point)] compare-combining-char) 0)))
 
 (defn wide?
-  "Is code-point (a character or integer) in the East Asian Wide (W) or East Asian Full-width (F) category as defined in Unicode Technical Report #11 (and subsequent revisions)?"
+  "Is code-point† in the East Asian Wide (W) or East Asian Full-width (F) category as defined in Unicode Technical Report #11 (and subsequent revisions)?
+
+†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (let [cp (int code-point)]
@@ -113,7 +121,9 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
                (and (>= cp 0x30000) (<= cp 0x3FFFD)))))))  ; CJK Symbols and Punctuation
 
 (defn wcwidth
-  "Returns the number of columns needed to represent the code-point. If code-point is a printable character, the value is at least 0. If code-point is a null character, the value is 0. Otherwise, -1 is returned."
+  "Returns the number of columns needed to represent the code-point†. If code-point is a printable character, the value is at least 0. If code-point is a null character, the value is 0. Otherwise, -1 is returned.
+
+†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (let [cp (int code-point)]
@@ -145,7 +155,7 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
         (reduce + ws)))))
 
 (defn wcswidth2
-  "Returns the number of columns needed to represent String s, ignoring nonprintable characters (note: this variant is not provided by POSIX, but is arguably more useful on the JVM given how it handles such characters)."
+  "Returns the number of columns needed to represent String s, ignoring nonprintable characters (note: this variant is not provided by POSIX, but is arguably more useful on the JVM)."
   [s]
   (when s
     (reduce + (remove #(<= % 0) (widths s)))))

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -98,7 +98,7 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
     (>= (java.util.Collections/binarySearch combining-char-ranges [(int code-point)] compare-combining-char) 0)))
 
 (defn wide?
-  "Is code-point† in the East Asian Wide (W) or East Asian Full-width (F) category as defined in Unicode Technical Report #11 (and subsequent revisions)?
+  "Is code-point† in the East Asian Wide (W) or East Asian Full-width (F) category?
 
 †a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]

--- a/test/wcwidth/api_test.clj
+++ b/test/wcwidth/api_test.clj
@@ -18,7 +18,6 @@
 
 (ns wcwidth.api-test
   (:require [clojure.test   :refer [deftest testing is]]
-            [clojure.string :as s]
             [wcwidth.api    :as wcw]))
 
 (def code-point-clown-emoji          0x1F921)   ; 🤡


### PR DESCRIPTION
com.github.pmonks/clj-wcwidth release v1.0.24. See commit log for details of what's included in this release.