### PR TITLE
Release v1.0.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,21 +62,23 @@ $ lein try com.github.pmonks/clj-wcwidth
 
 ; Showing the difference between the POSIX wcswidth behaviour and the more useful for Clojure,
 ; but non-POSIX, display-width behaviour:
-(wcw/wcswidth (str "hello, world" (wcw/codepoint-to-string 0x0084)))   ; non-printing code point
-; ==> -1
-(wcw/display-width (str "hello, world" (wcw/codepoint-to-string 0x0084)))
-; ==> 12
+(let [example-string (str "hello, world" (wcw/codepoint-to-string 0x0084))]   ; non-printing code point
+  (wcw/display-width example-string)
+  ; ==> 12
+  (wcw/wcswidth example-string)
+  ; ==> -1
 
-; Also show why clojure.core/count gives incorrect results when non-printing code points are
-; present:
-(count (str "hello, world" (wcw/codepoint-to-string 0x0084)))
-; ==> 13
+  ; Also show why clojure.core/count gives incorrect results when non-printing code points are
+  ; present:
+  (count example-string))
+  ; ==> 13
 
 ; And then show how a single width code point in a supplementary plane gets miscounted by count:
-(wcw/display-width (wcw/codepoint-to-string 0x10400))  ; 𐐀
-; ==> 1
-(count (wcw/codepoint-to-string 0x10400))
-; ==> 2
+(let [example-string (wcw/codepoint-to-string 0x10400)]  ; 𐐀
+  (wcw/display-width example-string)
+  ; ==> 1
+  (count  example-string))
+  ; ==> 2
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -60,13 +60,15 @@ $ lein try com.github.pmonks/clj-wcwidth
 (wcw/display-width "hello, 🤡")
 ; ==> 9
 
-; Showing the difference between the POSIX wcswidth behaviour and the more useful for Clojure, but non-POSIX, display-width behaviour:
+; Showing the difference between the POSIX wcswidth behaviour and the more useful for Clojure,
+; but non-POSIX, display-width behaviour:
 (wcw/wcswidth (str "hello, world" (wcw/codepoint-to-string 0x0084)))   ; non-printing code point
 ; ==> -1
 (wcw/display-width (str "hello, world" (wcw/codepoint-to-string 0x0084)))
 ; ==> 12
 
-; Also show why clojure.count/count gives incorrect results when non-printing code points are present:
+; Also show why clojure.count/count gives incorrect results when non-printing code points are
+; present:
 (count (str "hello, world" (wcw/codepoint-to-string 0x0084)))
 ; ==> 13
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ lein try com.github.pmonks/clj-wcwidth
 (wcw/display-width (str "hello, world" (wcw/codepoint-to-string 0x0084)))
 ; ==> 12
 
-; Also show why clojure.count/count gives incorrect results when non-printing code points are
+; Also show why clojure.core/count gives incorrect results when non-printing code points are
 ; present:
 (count (str "hello, world" (wcw/codepoint-to-string 0x0084)))
 ; ==> 13

--- a/README.md
+++ b/README.md
@@ -77,8 +77,15 @@ $ lein try com.github.pmonks/clj-wcwidth
 (let [example-string (wcw/codepoint-to-string 0x10400)]  ; 𐐀
   (wcw/display-width example-string)
   ; ==> 1
-  (count  example-string))
+  (count example-string))
   ; ==> 2
+
+; And another example of how count doesn't return display widths:
+(let [example-string "👍👍🏻"]
+  (wcw/display-width example-string)
+  ; ==> 4
+  (count example-string))
+  ; ==> 6
 ```
 
 ## Usage

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -22,7 +22,9 @@
 (defn codepoint-to-string
   "Converts any Unicode codepoint to a String.
 
-This is useful because Clojure/Java string literals only support UTF-16 escape sequences for code points, which involves manual conversion of all supplementary code points into pairs of escapes."
+This is useful because Clojure/Java string literals only support UTF-16 escape
+sequences for code points, which involves manual conversion of all supplementary
+code points into pairs of escapes."
   [^Integer code-point]
   (when code-point
     (s/join (java.lang.Character/toChars code-point))))
@@ -56,7 +58,8 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
    [0x1D242 0x1D244] [0x1F3FB 0x1F3FF] [0xE0001 0xE0001] [0xE0020 0xE007F] [0xE0100 0xE01EF]])
 
 (defn- compare-combining-char
-  "A comparator for comparing a code-point (within a singleton vector) against a single range from combining-char-ranges."
+  "A comparator for comparing a code-point (within a singleton vector) against a
+   single range from combining-char-ranges."
   [a b]
   ; We have to do these shenanigans as java.util.Collections/binarySearch assumes we're comparing identical types
   ; (which we're not, in this case, at least conceptually), and hence will hand them to us in any order.
@@ -73,7 +76,8 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
 (defn null?
   "Is code-point† a null character?
 
-†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
+†a character or integer, but note that Java/Clojure characters are limited to
+the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (= 0x0000 (int code-point))))
@@ -81,7 +85,8 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
 (defn non-printing?
   "Is code-point† a non-printing character?
 
-†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
+†a character or integer, but note that Java/Clojure characters are limited to
+the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (let [cp (int code-point)]
@@ -92,7 +97,8 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
 (defn combining?
   "Is code-point† a combining character?
 
-†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
+†a character or integer, but note that Java/Clojure characters are limited to
+the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (>= (java.util.Collections/binarySearch combining-char-ranges [(int code-point)] compare-combining-char) 0)))
@@ -100,7 +106,8 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
 (defn wide?
   "Is code-point† in the East Asian Wide (W) or East Asian Full-width (F) category?
 
-†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
+†a character or integer, but note that Java/Clojure characters are limited to
+the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (let [cp (int code-point)]
@@ -123,7 +130,8 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
 (defn wcwidth
   "Returns the number of columns needed to represent the code-point†. If code-point is a printable character, the value is at least 0. If code-point is a null character, the value is 0. Otherwise, -1 is returned.
 
-†a character or integer, but note that Java/Clojure characters are limited to the Unicode basic plane (first 0xFFFF code points) for historical reasons"
+†a character or integer, but note that Java/Clojure characters are limited to
+the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   [code-point]
   (when code-point
     (let [cp (int code-point)]
@@ -146,7 +154,8 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
   (map wcwidth (code-points s)))
 
 (defn wcswidth
-  "Returns the number of columns needed to represent String s. If a nonprintable character occurs among these characters, -1 is returned."
+  "Returns the number of columns needed to represent String s. If a nonprintable
+   character occurs among these characters, -1 is returned."
   [s]
   (when s
     (let [ws (widths s)]
@@ -155,7 +164,8 @@ This is useful because Clojure/Java string literals only support UTF-16 escape s
         (reduce + ws)))))
 
 (defn display-width
-  "Returns the number of columns needed to display String s, ignoring nonprintable characters. For Clojure, this is generally more useful than wcswidth."
+  "Returns the number of columns needed to display String s, ignoring
+   nonprintable characters. For Clojure, this is generally more useful than wcswidth."
   [s]
   (when s
     (reduce + (remove #(<= % 0) (widths s)))))

--- a/test/wcwidth/api_test.clj
+++ b/test/wcwidth/api_test.clj
@@ -80,8 +80,12 @@
 (deftest test-wcswidth
   (testing "ASCII-only strings"
     (is (=  3 (wcw/wcswidth "foo")))
-    (is (= 12 (wcw/wcswidth "hello, world")))
-    (is (= 28 (wcw/wcswidth "Copyright © Peter Monks 2022")))
+    (is (= 12 (wcw/wcswidth "hello, world"))))
+
+  (testing "Unicode - all single width"
+    (is (= 28 (wcw/wcswidth "Copyright © Peter Monks 2022"))))
+
+  (testing "Unicode - mixed widths"
     (is (= 10 (wcw/wcswidth "पीटर मोंक्सो")))
     (is (= 11 (wcw/wcswidth "彼得·蒙克斯")))
     (is (=  9 (wcw/wcswidth (str "hello, " (wcw/codepoint-to-string code-point-clown-emoji)))))
@@ -90,8 +94,12 @@
 (deftest test-display-width
   (testing "ASCII-only strings"
     (is (=  3 (wcw/display-width "foo")))
-    (is (= 12 (wcw/display-width "hello, world")))
-    (is (= 28 (wcw/display-width "Copyright © Peter Monks 2022")))
+    (is (= 12 (wcw/display-width "hello, world"))))
+
+  (testing "Unicode - all single width"
+    (is (= 28 (wcw/display-width "Copyright © Peter Monks 2022"))))
+
+  (testing "Unicode - mixed widths"
     (is (= 10 (wcw/display-width "पीटर मोंक्सो")))
     (is (= 11 (wcw/display-width "彼得·蒙克斯")))
     (is (=  9 (wcw/display-width (str "hello, " (wcw/codepoint-to-string code-point-clown-emoji)))))


### PR DESCRIPTION
com.github.pmonks/clj-wcwidth release v1.0.32. See commit log for details of what's included in this release.