### PR TITLE
Release v1.0.38

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This library provides a pure, zero-dependency Clojure implementation of the rule
 
 ## Why not `count`?
 
-When supplied with a string, [`count`](https://clojuredocs.org/clojure.core/count) counts the number of Java `char`s in that string, which (due to a historical oddity of the JVM) is not necessarily the same thing as a Unicode code point (Java `char`s are UTF-16 "code units", and Unicode code points in the supplementary planes require two such code units and therefore get counted as 2 `char`s on the JVM).  It also doesn't take non-printing and zero-width characters into account.
+When supplied with a string, [`count`](https://clojuredocs.org/clojure.core/count) counts the number of Java `char`s in that string, which (due to a historical oddity of the JVM) is not necessarily the same thing as a Unicode code point (Java `char`s are UTF-16 "code units", and Unicode code points in the supplementary planes require two such code units and therefore get counted as 2 `char`s on the JVM).  It also doesn't take non-printing and zero-width characters into account (more accurately, it counts them when it shouldn't).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This library provides a pure, zero-dependency Clojure implementation of the rule
 
 ## Why not `count`?
 
-When supplied with a string, [`count`](https://clojuredocs.org/clojure.core/count) counts the number of Java `char`s in that string, which (due to a historical oddity of the JVM) is not necessarily the same thing as a Unicode code point (Java `char`s are UTF-16 "code units", and Unicode code points in the supplementary planes require two such code units and therefore get counted as 2 `char`s on the JVM).  It also doesn't take non-printing and zero-width characters into account (more accurately, it counts them when it shouldn't).
+When supplied with a string, [`count`](https://clojuredocs.org/clojure.core/count) counts the number of Java `char`s in that string, which (due to a historical oddity of the JVM) is not necessarily the same thing as a Unicode code point (Java `char`s are UTF-16 "code units", and Unicode code points in the supplementary planes require two such UTF-16 code units and therefore get counted as 2 `char`s on the JVM).  It also doesn't take non-printing and zero-width characters into account (more accurately, it counts them as `char`s, even though they're non-visible when printed).
 
 ## Installation
 
@@ -57,30 +57,31 @@ $ lein try com.github.pmonks/clj-wcwidth
 
 (wcw/display-width "hello, world")
 ; ==> 12
-(wcw/display-width "hello, 🤡")
+(wcw/display-width "hello, 🌏")
 ; ==> 9
 
-; Showing the difference between the POSIX wcswidth behaviour and the more useful for Clojure,
-; but non-POSIX, display-width behaviour:
+; Showing the difference between the POSIX wcswidth behaviour and the more
+; useful for Clojure, but non-POSIX, display-width behaviour:
 (let [example-string (str "hello, world" (wcw/codepoint-to-string 0x0084))]   ; non-printing code point
   (wcw/display-width example-string)
   ; ==> 12
   (wcw/wcswidth example-string)
   ; ==> -1
 
-  ; Also show why clojure.core/count gives incorrect results when non-printing code points are
-  ; present:
+  ; Also show why clojure.core/count gives incorrect results when non-printing
+  ; code points are present:
   (count example-string))
   ; ==> 13
 
-; And then show how a single width code point in a supplementary plane gets miscounted by count:
+; And then show how a single width code point in a supplementary plane gets
+; miscounted by count:
 (let [example-string (wcw/codepoint-to-string 0x10400)]  ; 𐐀
   (wcw/display-width example-string)
   ; ==> 1
   (count example-string))
   ; ==> 2
 
-; And another example of how count doesn't return display widths:
+; And another example of how count doesn't understand display columns:
 (let [example-string "👍👍🏻"]
   (wcw/display-width example-string)
   ; ==> 4

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -20,14 +20,18 @@
   (:require [clojure.string :as s]))
 
 (defn code-point-to-string
-  "Returns the string representation of any Unicode code point.
+  "Returns the string representation of any Unicode code point†.
 
 This is useful because Clojure/Java string literals only support UTF-16 escape
 sequences for code points, which involves manual conversion of all supplementary
-code points into pairs of escapes."
-  [^Integer code-point]
+code points into pairs of escapes.
+
+†a character or integer, but note that Java/Clojure characters are limited to
+the Unicode basic plane (first 0xFFFF code points) for historical reasons"
+  [code-point]
   (when code-point
-    (java.lang.Character/toString code-point)))
+    (s/join (java.lang.Character/toChars (int code-point)))))
+;    (java.lang.Character/toString code-point)))  ; Java 11+
 
 (defn code-points-to-string
   "Returns a string made up of all of the given code points†

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -19,15 +19,32 @@
 (ns wcwidth.api
   (:require [clojure.string :as s]))
 
-(defn codepoint-to-string
-  "Converts any Unicode codepoint to a String.
+(defn code-point-to-string
+  "Returns the string representation of any Unicode code point.
 
 This is useful because Clojure/Java string literals only support UTF-16 escape
 sequences for code points, which involves manual conversion of all supplementary
 code points into pairs of escapes."
   [^Integer code-point]
   (when code-point
-    (s/join (java.lang.Character/toChars code-point))))
+    (java.lang.Character/toString code-point)))
+
+(defn code-points-to-string
+  "Returns a string made up of all of the given code points†
+
+†a sequence of characters or integers, but note that Java/Clojure characters are
+limited to the Unicode basic plane (first 0xFFFF code points) for historical
+reasons"
+  [code-points]
+  (when code-points
+    (s/join (map #(code-point-to-string (int %)) code-points))))
+
+(defn string-to-code-points
+  "Returns all of the Unicode code points in s, as a sequence of integers."
+  [^String s]
+  (when s
+    (let [a (.toArray (.codePoints s))]
+      (when a (vec a)))))   ; Note: seq nil-puns empty sequences, and vec "empty-sequence-puns" nil, so we don't have a core fn to do exactly what we want!
 
 ; Copied directly from https://github.com/jline/jline3/blob/master/terminal/src/main/java/org/jline/utils/WCWidth.java#L80 as of 2021-11-14
 ; That code is BSD-3-Clause.
@@ -128,7 +145,9 @@ the Unicode basic plane (first 0xFFFF code points) for historical reasons"
                (and (>= cp 0x30000) (<= cp 0x3FFFD)))))))  ; CJK Symbols and Punctuation
 
 (defn wcwidth
-  "Returns the number of columns needed to represent the code-point†. If code-point is a printable character, the value is at least 0. If code-point is a null character, the value is 0. Otherwise, -1 is returned.
+  "Returns the number of columns needed to represent the code-point†. If
+  code-point is a printable character, the value is at least 0. If code-point is
+  a null character, the value is 0. Otherwise, -1 is returned.
 
 †a character or integer, but note that Java/Clojure characters are limited to
 the Unicode basic plane (first 0xFFFF code points) for historical reasons"
@@ -142,16 +161,10 @@ the Unicode basic plane (first 0xFFFF code points) for historical reasons"
         (wide? cp)          2
         :else               1))))
 
-(defn code-points
-  "Returns all of the Unicode code points in s, as a sequence of integers."
-  [^String s]
-  (when s
-    (seq (.toArray (.codePoints s)))))
-
 (defn- widths
   "Returns a sequence of all of the widths of the Characters in String s."
   [s]
-  (map wcwidth (code-points s)))
+  (map wcwidth (string-to-code-points s)))
 
 (defn wcswidth
   "Returns the number of columns needed to represent String s. If a nonprintable

--- a/test/wcwidth/api_test.clj
+++ b/test/wcwidth/api_test.clj
@@ -25,6 +25,9 @@
 (def code-point-non-printing-example 0x0094)
 
 (deftest test-codepoint-to-string
+  (testing "nil"
+    (is (nil? (wcw/codepoint-to-string nil))))
+
   (testing "ASCII codepoints"
     (is (=  " " (wcw/codepoint-to-string 0x0020)))    ; space
     (is (=  "#" (wcw/codepoint-to-string 0x0023)))    ; #
@@ -35,6 +38,9 @@
     (is (= "🤡" (wcw/codepoint-to-string code-point-clown-emoji)))))
 
 (deftest test-wcwidth
+  (testing "nil"
+    (is (nil? (wcw/wcwidth nil))))
+
   (testing "ASCII codes"
     (is (zero?  (wcw/wcwidth 0x0000)))    ; NUL
     (is (= -1   (wcw/wcwidth 0x007F)))    ; DEL
@@ -78,6 +84,10 @@
     (is (= 2 (wcw/wcwidth code-point-clown-emoji))))
 
 (deftest test-wcswidth
+  (testing "nil and empty"
+    (is (nil? (wcw/wcswidth nil)))
+    (is (= 0  (wcw/wcswidth ""))))
+
   (testing "ASCII-only strings"
     (is (=  3 (wcw/wcswidth "foo")))
     (is (= 12 (wcw/wcswidth "hello, world"))))
@@ -92,6 +102,10 @@
     (is (= -1 (wcw/wcswidth (str "hello, world" (wcw/codepoint-to-string code-point-non-printing-example)))))))
 
 (deftest test-display-width
+  (testing "nil and empty"
+    (is (nil? (wcw/display-width nil)))
+    (is (= 0  (wcw/display-width ""))))
+
   (testing "ASCII-only strings"
     (is (=  3 (wcw/display-width "foo")))
     (is (= 12 (wcw/display-width "hello, world"))))

--- a/test/wcwidth/api_test.clj
+++ b/test/wcwidth/api_test.clj
@@ -21,21 +21,63 @@
             [wcwidth.api    :as wcw]))
 
 (def code-point-clown-emoji          0x1F921)   ; 🤡
+(def code-point-globe-asia           0x1F30F)   ; 🌏
 (def code-point-combining-example    0x1D177)
 (def code-point-non-printing-example 0x0094)
 
-(deftest test-codepoint-to-string
-  (testing "nil"
-    (is (nil? (wcw/codepoint-to-string nil))))
+(deftest test-code-point-to-string
+  (testing "nil and empty"
+    (is (nil? (wcw/code-point-to-string nil))))
 
-  (testing "ASCII codepoints"
-    (is (=  " " (wcw/codepoint-to-string 0x0020)))    ; space
-    (is (=  "#" (wcw/codepoint-to-string 0x0023)))    ; #
-    (is (=  "6" (wcw/codepoint-to-string 0x0036)))    ; 6
-    (is (=  "A" (wcw/codepoint-to-string 0x0041))))   ; A
+  (testing "ASCII code points"
+    (is (=  " " (wcw/code-point-to-string 0x0020)))
+    (is (=  "#" (wcw/code-point-to-string 0x0023)))
+    (is (=  "6" (wcw/code-point-to-string 0x0036)))
+    (is (=  "A" (wcw/code-point-to-string 0x0041))))
 
-  (testing "Unicode codepoints"
-    (is (= "🤡" (wcw/codepoint-to-string code-point-clown-emoji)))))
+  (testing "Unicode code points"
+    (is (= "🤡" (wcw/code-point-to-string code-point-clown-emoji)))))
+
+(deftest test-code-points-to-string
+  (testing "nil and empty"
+    (is (nil? (wcw/code-points-to-string nil)))
+    (is (= "" (wcw/code-points-to-string []))))
+
+  (testing "ASCII code point"
+    (is (=  " " (wcw/code-points-to-string [0x0020])))
+    (is (=  "#" (wcw/code-points-to-string [0x0023])))
+    (is (=  "6" (wcw/code-points-to-string [0x0036])))
+    (is (=  "A" (wcw/code-points-to-string [0x0041]))))
+
+  (testing "Unicode code point"
+    (is (= "🤡" (wcw/code-points-to-string [code-point-clown-emoji]))))
+
+  (testing "Sequence of code points"
+    (is (= "Hello, 🌏!" (wcw/code-points-to-string [\H \e \l \l \o \, \space code-point-globe-asia \!])))))
+
+(deftest test-string-to-code-points
+  (testing "nil and empty"
+    (is (nil? (wcw/string-to-code-points nil)))
+    (is (= [] (wcw/string-to-code-points ""))))
+
+  (testing "ASCII code point"
+    (is (= [0x0020] (wcw/string-to-code-points " ")))
+    (is (= [0x0023] (wcw/string-to-code-points "#" )))
+    (is (= [0x0036] (wcw/string-to-code-points "6")))
+    (is (= [0x0041] (wcw/string-to-code-points "A"))))
+
+  (testing "Unicode code point"
+    (is (= [code-point-clown-emoji] (wcw/string-to-code-points "🤡"))))
+
+  (testing "Sequence of code points"
+    (is (= [(int \H) (int \e) (int \l) (int \l) (int \o) (int \,) (int \space) code-point-globe-asia (int \!)]
+           (wcw/string-to-code-points "Hello, 🌏!")))))
+
+(deftest test-roundtripping
+  (testing "Roundtripping of string-to-code-points and code-points-to-string"
+    (doall
+      (for [test [nil "" " " "\t" "\n" "Hello, world!" "Hello, 🌏!" "पीटर मोंक्सो" "彼得·蒙克斯"]]
+        (is (= test (wcw/code-points-to-string (wcw/string-to-code-points test))))))))
 
 (deftest test-wcwidth
   (testing "nil"
@@ -98,8 +140,8 @@
   (testing "Unicode - mixed widths"
     (is (= 10 (wcw/wcswidth "पीटर मोंक्सो")))
     (is (= 11 (wcw/wcswidth "彼得·蒙克斯")))
-    (is (=  9 (wcw/wcswidth (str "hello, " (wcw/codepoint-to-string code-point-clown-emoji)))))
-    (is (= -1 (wcw/wcswidth (str "hello, world" (wcw/codepoint-to-string code-point-non-printing-example)))))))
+    (is (=  9 (wcw/wcswidth (str "hello, " (wcw/code-point-to-string code-point-clown-emoji)))))
+    (is (= -1 (wcw/wcswidth (str "hello, world" (wcw/code-point-to-string code-point-non-printing-example)))))))
 
 (deftest test-display-width
   (testing "nil and empty"
@@ -116,5 +158,5 @@
   (testing "Unicode - mixed widths"
     (is (= 10 (wcw/display-width "पीटर मोंक्सो")))
     (is (= 11 (wcw/display-width "彼得·蒙克斯")))
-    (is (=  9 (wcw/display-width (str "hello, " (wcw/codepoint-to-string code-point-clown-emoji)))))
-    (is (= 12 (wcw/display-width (str "hello, world" (wcw/codepoint-to-string code-point-non-printing-example)))))))
+    (is (=  9 (wcw/display-width (str "hello, " (wcw/code-point-to-string code-point-clown-emoji)))))
+    (is (= 12 (wcw/display-width (str "hello, world" (wcw/code-point-to-string code-point-non-printing-example)))))))


### PR DESCRIPTION
com.github.pmonks/clj-wcwidth release v1.0.38. See commit log for details of what's included in this release.