### PR TITLE
Release v1.0.51

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-      - uses: DeLaGuardo/setup-clojure@7.0
+      - uses: DeLaGuardo/setup-clojure@8.0
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: DeLaGuardo/setup-clojure@7.0
+      - uses: DeLaGuardo/setup-clojure@8.0
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: DeLaGuardo/setup-clojure@7.0
+      - uses: DeLaGuardo/setup-clojure@8.0
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -57,33 +57,30 @@ $ lein try com.github.pmonks/clj-wcwidth
 (wcw/wcwidth 0x1F921)  ; 🤡 (double width)
 ; ==> 2
 
-(wcw/display-width "hello, world")
+(wcw/display-width "hello, world")  ; all single width
 ; ==> 12
-(wcw/display-width "hello, 🌏")
+(wcw/display-width "hello, 🌏")     ; mixed single and double width
 ; ==> 9
 
 ; Showing the difference between the POSIX wcswidth behaviour and the more
-; useful for Clojure, but non-POSIX, display-width behaviour:
+; useful in Clojure, but non-POSIX, display-width behaviour:
 (let [example-string (str "hello, world" (wcw/code-point-to-string 0x0084))]   ; non-printing code point
   (wcw/display-width example-string)
   ; ==> 12
   (wcw/wcswidth example-string)
   ; ==> -1
 
-  ; Also show why clojure.core/count gives incorrect results when non-printing
-  ; code points are present:
+  ; Also show why clojure.core/count is inappropriate for determining display width:
   (count example-string))
   ; ==> 13
 
-; And then show how a single width code point in a supplementary plane gets
-; miscounted by count:
+; More examples showing why clojure.core/count is inappropriate for determining display width:
 (let [example-string (wcw/code-point-to-string 0x10400)]  ; 𐐀
   (wcw/display-width example-string)
   ; ==> 1
   (count example-string))
   ; ==> 2
 
-; And another example of how count doesn't understand display columns:
 (let [example-string "👍👍🏻"]
   (wcw/display-width example-string)
   ; ==> 4

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ lein try com.github.pmonks/clj-wcwidth
 
 ; Showing the difference between the POSIX wcswidth behaviour and the more
 ; useful for Clojure, but non-POSIX, display-width behaviour:
-(let [example-string (str "hello, world" (wcw/codepoint-to-string 0x0084))]   ; non-printing code point
+(let [example-string (str "hello, world" (wcw/code-point-to-string 0x0084))]   ; non-printing code point
   (wcw/display-width example-string)
   ; ==> 12
   (wcw/wcswidth example-string)
@@ -75,7 +75,7 @@ $ lein try com.github.pmonks/clj-wcwidth
 
 ; And then show how a single width code point in a supplementary plane gets
 ; miscounted by count:
-(let [example-string (wcw/codepoint-to-string 0x10400)]  ; 𐐀
+(let [example-string (wcw/code-point-to-string 0x10400)]  ; 𐐀
   (wcw/display-width example-string)
   ; ==> 1
   (count example-string))

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ lein try com.github.pmonks/clj-wcwidth
 (wcw/wcwidth \©)
 ; ==> 1
 (wcw/wcwidth 0x0000)   ; ASCII NUL (zero width)
-; ==> 0   (nul)
+; ==> 0
 (wcw/wcwidth 0x001B)   ; ASCII ESC (non printing)
 ; ==> -1
 (wcw/wcwidth 0x1F921)  ; 🤡 (double width)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Java doesn't provide these functions however, so applications that need to know 
 
 This library provides a pure, zero-dependency Clojure implementation of the rules described in UTR-11 (and updated for recent Unicode versions), to avoid having to do that.
 
-## Why not `count`?
+## Why not [`count`](https://clojuredocs.org/clojure.core/count)?
 
-When supplied with a string, [`count`](https://clojuredocs.org/clojure.core/count) counts the number of Java `char`s in that string, which (due to a historical oddity of the JVM) is not necessarily the same thing as a Unicode code point (Java `char`s are UTF-16 "code units", and Unicode code points in the supplementary planes require two such UTF-16 code units and therefore get counted as 2 `char`s on the JVM).  It also doesn't take non-printing and zero-width characters into account (more accurately, it counts them as `char`s, even though they're non-visible when printed).
+When supplied with a sequence of characters (normally a `String`, though also a Java `char[]`), `count` simply counts the number of Java `char`s in that sequence, which, due to a [historical oddity of the JVM](https://www.oracle.com/technical-resources/articles/javase/supplementary.html), is not necessarily the same thing as a Unicode code point (what we generally now think of as a "character"). Specifically, Java `char`s are a 16 bit "code unit" from UTF-16, and Unicode code points in the supplementary planes can only be represented by two such code units (and therefore get counted as 2 `char`s on the JVM, when present in a sequence of characters).
+
+Furthermore, `count` doesn't account for non-printing and zero-width Unicode code points; it counts them as `char`s even though they take up zero width when printed.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This library provides a pure, zero-dependency Clojure implementation of the rule
 
 ## Why not [`count`](https://clojuredocs.org/clojure.core/count)?
 
-When supplied with a sequence of characters (normally a `String`, though also a Java `char[]`), `count` simply counts the number of Java `char`s in that sequence, which, due to a [historical oddity of the JVM](https://www.oracle.com/technical-resources/articles/javase/supplementary.html), is not necessarily the same thing as a Unicode code point (what we generally now think of as a "character"). Specifically, Java `char`s are a 16 bit "code unit" from UTF-16, and Unicode code points in the supplementary planes can only be represented by two such code units (and therefore get counted as 2 `char`s on the JVM, when present in a sequence of characters).
+When supplied with a sequence of characters (normally a `String`, though also a Java `char[]`), `count` simply counts the number of Java `char`s in that sequence, which, due to a [historical oddity of the JVM](https://www.oracle.com/technical-resources/articles/javase/supplementary.html), is not necessarily the same thing as a Unicode code point (what we generally now think of as a "character"). Specifically, Java `char`s are a 16 bit "code unit" from UTF-16, and Unicode code points in the supplementary planes are represented by two such code units (and therefore get counted as 2 `char`s on the JVM, when present in a sequence of characters).
 
 Furthermore, `count` doesn't account for non-printing and zero-width Unicode code points; it counts them as `char`s even though they take up zero width when printed.
 

--- a/deps.edn
+++ b/deps.edn
@@ -18,7 +18,7 @@
 
 {:aliases
    {:build
-      {:deps        {io.github.seancorfield/build-clj {:git/tag "v0.8.2" :git/sha "0ffdb4c"}
+      {:deps        {io.github.seancorfield/build-clj {:git/tag "v0.8.3" :git/sha "7ac1f8d"}
                      com.github.pmonks/pbr            {:mvn/version "RELEASE"}}
        :ns-default  pbr.build
        :extra-paths ["src"]}}}  ; To appease codox...

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -22,9 +22,9 @@
 (defn code-point-to-string
   "Returns the string representation of any Unicode code point†.
 
-This is useful because Clojure/Java string literals only support UTF-16 escape
-sequences for code points, which involves manual conversion of all supplementary
-code points into pairs of escapes.
+This is useful because Clojure/Java string literals only support escape
+sequences for code points in the basic plane, which involves manual conversion
+of all supplementary code points into pairs of escapes.
 
 †a character or integer, but note that Java/Clojure characters are limited to
 the Unicode basic plane (first 0xFFFF code points) for historical reasons"
@@ -41,7 +41,7 @@ limited to the Unicode basic plane (first 0xFFFF code points) for historical
 reasons"
   [code-points]
   (when code-points
-    (s/join (map #(code-point-to-string (int %)) code-points))))
+    (s/join (map code-point-to-string code-points))))
 
 (defn string-to-code-points
   "Returns all of the Unicode code points in s, as a sequence of integers."
@@ -125,7 +125,7 @@ the Unicode basic plane (first 0xFFFF code points) for historical reasons"
     (>= (java.util.Collections/binarySearch combining-char-ranges [(int code-point)] compare-combining-char) 0)))
 
 (defn wide?
-  "Is code-point† in the East Asian Wide (W) or East Asian Full-width (F) category?
+  "Is code-point† in the East Asian Wide (W), East Asian Full-width (F), or other wide character (e.g. emoji) category?
 
 †a character or integer, but note that Java/Clojure characters are limited to
 the Unicode basic plane (first 0xFFFF code points) for historical reasons"
@@ -160,14 +160,14 @@ the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   (when code-point
     (let [cp (int code-point)]
       (cond
-        (null? cp)          0
+        (null?         cp)  0
         (non-printing? cp) -1
-        (combining? cp)     0
-        (wide? cp)          2
+        (combining?    cp)  0
+        (wide?         cp)  2
         :else               1))))
 
 (defn- widths
-  "Returns a sequence of all of the widths of the Characters in String s."
+  "Returns a lazy sequence of all of the widths of the Characters in String s."
   [s]
   (map wcwidth (string-to-code-points s)))
 

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -172,7 +172,7 @@ the Unicode basic plane (first 0xFFFF code points) for historical reasons"
   (map wcwidth (string-to-code-points s)))
 
 (defn wcswidth
-  "Returns the number of columns needed to represent String s. If a nonprintable
+  "Returns the number of columns needed to represent String s. If a non-printing
 character occurs among these characters, -1 is returned."
   [s]
   (when s
@@ -182,7 +182,7 @@ character occurs among these characters, -1 is returned."
         (reduce + ws)))))
 
 (defn display-width
-  "Returns the number of columns needed to display String s, ignoring nonprintable
+  "Returns the number of columns needed to display String s, ignoring non-printing
 characters. For Clojure, this is generally more useful than wcswidth."
   [s]
   (when s

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -80,7 +80,7 @@ reasons"
 
 (defn- compare-combining-char
   "A comparator for comparing a code-point (within a singleton vector) against a
-   single range from combining-char-ranges."
+single range from combining-char-ranges."
   [a b]
   ; We have to do these shenanigans as java.util.Collections/binarySearch assumes we're comparing identical types
   ; (which we're not, in this case, at least conceptually), and hence will hand them to us in any order.
@@ -150,8 +150,9 @@ the Unicode basic plane (first 0xFFFF code points) for historical reasons"
 
 (defn wcwidth
   "Returns the number of columns needed to represent the code-point†. If
-  code-point is a printable character, the value is at least 0. If code-point is
-  a null character, the value is 0. Otherwise, -1 is returned.
+code-point is a printable character, the value is at least 0. If code-point is
+a null character, the value is 0. Otherwise, -1 is returned (the code-point is
+non-printing).
 
 †a character or integer, but note that Java/Clojure characters are limited to
 the Unicode basic plane (first 0xFFFF code points) for historical reasons"
@@ -172,7 +173,7 @@ the Unicode basic plane (first 0xFFFF code points) for historical reasons"
 
 (defn wcswidth
   "Returns the number of columns needed to represent String s. If a nonprintable
-   character occurs among these characters, -1 is returned."
+character occurs among these characters, -1 is returned."
   [s]
   (when s
     (let [ws (widths s)]
@@ -181,8 +182,8 @@ the Unicode basic plane (first 0xFFFF code points) for historical reasons"
         (reduce + ws)))))
 
 (defn display-width
-  "Returns the number of columns needed to display String s, ignoring
-   nonprintable characters. For Clojure, this is generally more useful than wcswidth."
+  "Returns the number of columns needed to display String s, ignoring nonprintable
+characters. For Clojure, this is generally more useful than wcswidth."
   [s]
   (when s
     (reduce + (remove #(<= % 0) (widths s)))))

--- a/test/wcwidth/api_test.clj
+++ b/test/wcwidth/api_test.clj
@@ -127,8 +127,8 @@
 
 (deftest test-wcswidth
   (testing "nil and empty"
-    (is (nil? (wcw/wcswidth nil)))
-    (is (= 0  (wcw/wcswidth ""))))
+    (is (nil?  (wcw/wcswidth nil)))
+    (is (zero? (wcw/wcswidth ""))))
 
   (testing "ASCII-only strings"
     (is (=  3 (wcw/wcswidth "foo")))
@@ -145,8 +145,8 @@
 
 (deftest test-display-width
   (testing "nil and empty"
-    (is (nil? (wcw/display-width nil)))
-    (is (= 0  (wcw/display-width ""))))
+    (is (nil?  (wcw/display-width nil)))
+    (is (zero? (wcw/display-width ""))))
 
   (testing "ASCII-only strings"
     (is (=  3 (wcw/display-width "foo")))

--- a/test/wcwidth/api_test.clj
+++ b/test/wcwidth/api_test.clj
@@ -26,7 +26,7 @@
 (def code-point-non-printing-example 0x0094)
 
 (deftest test-code-point-to-string
-  (testing "nil and empty"
+  (testing "nil"
     (is (nil? (wcw/code-point-to-string nil))))
 
   (testing "ASCII code points"


### PR DESCRIPTION
com.github.pmonks/clj-wcwidth release v1.0.51. See commit log for details of what's included in this release.