### PR TITLE
Fix for issue #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pure Clojure implementations of the [`wcwidth`](https://man7.org/linux/man-pages
 
 ## Why?
 
-When printing Unicode characters to a fixed-width display device (e.g. a terminal), every Unicode code point has a well-defined "column width".  This was originally standardised in [Unicode Technical Report #11](https://unicode.org/reports/tr11-5/), and implemented as the POSIX functions `wcwidth` and `wcswidth` soon after.
+When printing Unicode characters to a fixed-width display device (e.g. a terminal), every Unicode code point has a well-defined "column width".  This has been standardised in [Unicode Technical Report #11](https://www.unicode.org/reports/tr11/), and implemented as the POSIX functions `wcwidth` and `wcswidth`.
 
 Java doesn't provide these functions however, so applications that need to know these widths (e.g. for terminal screen formatting purposes) are left to their own devices.  While there are Java libraries that have implemented this themselves (notably [JLine](https://github.com/jline/jline3/blob/master/terminal/src/main/java/org/jline/utils/WCWidth.java)), pulling in a large dependency when one only uses a very small part of it is sometimes overkill.
 

--- a/test/wcwidth/api_test.clj
+++ b/test/wcwidth/api_test.clj
@@ -24,6 +24,7 @@
 (def code-point-globe-asia           0x1F30F)   ; 🌏
 (def code-point-combining-example    0x1D177)
 (def code-point-non-printing-example 0x0094)
+(def code-point-medium-white-circle  0x26AA)    ; ⚪️ - this one is tricky as UTR#11 doesn't define a width for it - it's in the "Miscellaenous symbols" category, rather than the emoji category
 
 (deftest test-code-point-to-string
   (testing "nil"
@@ -123,7 +124,8 @@
     (is (= 1 (wcw/wcwidth 0x10400))))   ; 𐐀
 
   (testing "Unicode - double width")
-    (is (= 2 (wcw/wcwidth code-point-clown-emoji))))
+    (is (= 2 (wcw/wcwidth code-point-clown-emoji)))
+    (is (= 2 (wcw/wcwidth code-point-medium-white-circle))))  ; Note: this isn't aligned with UTR#11, but it works better in practice
 
 (deftest test-wcswidth
   (testing "nil and empty"


### PR DESCRIPTION
Addresses issue #8.

Summary of changes:

* Adds support for additional emoji codepoint range, as per [this alternative `wcwidth` implementation (BSD-2-Clause licensed)](https://github.com/fumiyas/wcwidth-cjk/blob/master/wcwidth.c#L296-L297)