### PR TITLE
Release v1.0.58

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When printing Unicode characters to a fixed-width display device (e.g. a termina
 
 Java doesn't provide these functions however, so applications that need to know these widths (e.g. for terminal screen formatting purposes) are left to their own devices.  While there are Java libraries that have implemented this themselves (notably [JLine](https://github.com/jline/jline3/blob/master/terminal/src/main/java/org/jline/utils/WCWidth.java)), pulling in a large dependency when one only uses a very small part of it is sometimes overkill.
 
-This library provides a pure, zero-dependency Clojure implementation of the rules described in UTR-11 (and updated for recent Unicode versions), to avoid having to do that.
+This library provides a small, zero-dependency, pure Clojure implementation of the rules described in UTR-11 (and updated for recent Unicode versions), to avoid having to do that.
 
 ## Why not [`count`](https://clojuredocs.org/clojure.core/count)?
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pure Clojure implementations of the [`wcwidth`](https://man7.org/linux/man-pages
 
 ## Why?
 
-When printing Unicode characters to a fixed-width display device (e.g. a terminal), every Unicode code point has a well-defined "column width".  This was originally standardised in [Unicode Technical Report #11](https://unicode.org/reports/tr11-5/), and implemented as the POSIX functions `wcwidth` and `wcswidth` soon after.
+When printing Unicode characters to a fixed-width display device (e.g. a terminal), every Unicode code point has a well-defined "column width".  This has been standardised in [Unicode Technical Report #11](https://www.unicode.org/reports/tr11/), and implemented as the POSIX functions `wcwidth` and `wcswidth`.
 
 Java doesn't provide these functions however, so applications that need to know these widths (e.g. for terminal screen formatting purposes) are left to their own devices.  While there are Java libraries that have implemented this themselves (notably [JLine](https://github.com/jline/jline3/blob/master/terminal/src/main/java/org/jline/utils/WCWidth.java)), pulling in a large dependency when one only uses a very small part of it is sometimes overkill.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This library provides a small, zero-dependency, pure Clojure implementation of t
 
 ## Why not [`count`](https://clojuredocs.org/clojure.core/count)?
 
-When supplied with a sequence of characters (normally a `String`, though also a Java `char[]`), `count` simply counts the number of Java `char`s in that sequence, which, due to a [historical oddity of the JVM](https://www.oracle.com/technical-resources/articles/javase/supplementary.html), is not necessarily the same thing as a Unicode code point (what we generally now think of as a "character"). Specifically, Java `char`s are a 16 bit "code unit" from UTF-16, and Unicode code points in the supplementary planes are represented by two such code units (and therefore get counted as 2 `char`s on the JVM, when present in a sequence of characters).
+When supplied with a sequence of characters (normally a `String`, though also a Java `char[]`), `count` simply counts the number of Java `char`s in that sequence, which, due to a [historical oddity of the JVM](https://www.oracle.com/technical-resources/articles/javase/supplementary.html), is not necessarily the same thing as a Unicode code point (what we generally now think of as a "character"). Specifically, Java `char`s are a 16 bit "code unit" from UTF-16, and Unicode code points in the supplementary planes are represented by two such code units (and therefore as 2 `char`s on the JVM).
 
 Furthermore, `count` doesn't account for non-printing and zero-width Unicode code points; it counts them as `char`s even though they take up zero width when printed.
 

--- a/test/wcwidth/api_test.clj
+++ b/test/wcwidth/api_test.clj
@@ -139,6 +139,9 @@
   (testing "Unicode - all single width"
     (is (= 28 (wcw/wcswidth "Copyright © Peter Monks 2022"))))
 
+  (testing "Unicode - all double width, with some non-printing as well"
+    (is (= 4 (wcw/wcswidth (wcw/code-points-to-string [0x1F44D 0x1F44D 0x1F3FB])))))  ; 👍👍🏻 - note skin tone is controlled via a zero-width combining character
+
   (testing "Unicode - mixed widths"
     (is (= 10 (wcw/wcswidth "पीटर मोंक्सो")))
     (is (= 11 (wcw/wcswidth "彼得·蒙克斯")))
@@ -156,6 +159,9 @@
 
   (testing "Unicode - all single width"
     (is (= 28 (wcw/display-width "Copyright © Peter Monks 2022"))))
+
+  (testing "Unicode - all double width, with some non-printing as well"
+    (is (= 4 (wcw/wcswidth (wcw/code-points-to-string [0x1F44D 0x1F44D 0x1F3FB])))))  ; 👍👍🏻 - note skin tone is controlled via a zero-width combining character
 
   (testing "Unicode - mixed widths"
     (is (= 10 (wcw/display-width "पीटर मोंक्सो")))

--- a/test/wcwidth/api_test.clj
+++ b/test/wcwidth/api_test.clj
@@ -24,6 +24,7 @@
 (def code-point-globe-asia           0x1F30F)   ; 🌏
 (def code-point-combining-example    0x1D177)
 (def code-point-non-printing-example 0x0094)
+(def code-point-medium-white-circle  0x26AA)    ; ⚪️ - this one is tricky as UTR#11 doesn't define a width for it - it's in the "Miscellaenous symbols" category, rather than the emoji category
 
 (deftest test-code-point-to-string
   (testing "nil"
@@ -123,7 +124,8 @@
     (is (= 1 (wcw/wcwidth 0x10400))))   ; 𐐀
 
   (testing "Unicode - double width")
-    (is (= 2 (wcw/wcwidth code-point-clown-emoji))))
+    (is (= 2 (wcw/wcwidth code-point-clown-emoji)))
+    (is (= 2 (wcw/wcwidth code-point-medium-white-circle))))  ; Note: this isn't aligned with UTR#11, but it works better in practice
 
 (deftest test-wcswidth
   (testing "nil and empty"


### PR DESCRIPTION
com.github.pmonks/clj-wcwidth release v1.0.58. See commit log for details of what's included in this release.