### PR TITLE
Release 1.0.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-      - uses: DeLaGuardo/setup-clojure@9.2
+      - uses: DeLaGuardo/setup-clojure@9.3
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java-version }}
-      - uses: DeLaGuardo/setup-clojure@8.0
+      - uses: DeLaGuardo/setup-clojure@9.2
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: DeLaGuardo/setup-clojure@9.2
+      - uses: DeLaGuardo/setup-clojure@9.3
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: DeLaGuardo/setup-clojure@8.0
+      - uses: DeLaGuardo/setup-clojure@9.2
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: DeLaGuardo/setup-clojure@9.2
+      - uses: DeLaGuardo/setup-clojure@9.3
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-      - uses: DeLaGuardo/setup-clojure@8.0
+      - uses: DeLaGuardo/setup-clojure@9.2
         with:
           cli: latest
       - uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pure Clojure implementations of the [`wcwidth`](https://man7.org/linux/man-pages
 
 ## Why?
 
-When printing Unicode characters to a fixed-width display device (e.g. a terminal), every Unicode code point has a well-defined "column width".  This has been standardised in [Unicode Technical Report #11](https://www.unicode.org/reports/tr11/), and implemented as the POSIX functions `wcwidth` and `wcswidth`.
+When printing Unicode characters to a fixed-width display device (e.g. a terminal), many Unicode code points have a well-defined "column width".  This has been standardised in [Unicode Technical Report #11](https://www.unicode.org/reports/tr11/), and implemented as the POSIX functions `wcwidth` and `wcswidth`.
 
 Java doesn't provide these functions however, so applications that need to know these widths (e.g. for terminal screen formatting purposes) are left to their own devices.  While there are Java libraries that have implemented this themselves (notably [JLine](https://github.com/jline/jline3/blob/master/terminal/src/main/java/org/jline/utils/WCWidth.java)), pulling in a large dependency when one only uses a very small part of it is sometimes overkill.
 


### PR DESCRIPTION
com.github.pmonks/clj-wcwidth release 1.0.64. See commit log for details of what's included in this release.