### PR TITLE
Release 1.0.145

### DIFF
--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -58,7 +58,7 @@
 
 (defn string->code-points
   "Returns all of the Unicode code points in `cs` (a `CharSequence`), as a
-  sequence of `int`s, or `nil` when `s` is `nil`."
+  sequence of `int`s, or `nil` when `cs` is `nil`."
   [^CharSequence cs]
   (when cs
     (sequence (.toArray (.codePoints cs)))))
@@ -229,7 +229,6 @@
   "Returns a sequence of the [[wcwidth]]s of the grapheme clusters in `cs` (a
   `CharSequence`)."
   [^CharSequence cs]
-  #_{:clj-kondo/ignore [:unresolved-symbol]}
   (when-let [gcs (grapheme-clusters cs)]
     (map #(min 2 (reduce + (map wcwidth (string->code-points %)))) gcs)))
 
@@ -238,7 +237,7 @@
   a non-printing code point occurs in `cs`, `-1` is returned (as defined in
   POSIX).
 
-  Returns `0` when `s` is `nil`."
+  Returns `0` when `cs` is `nil`."
   ^long [^CharSequence cs]
   (if-let [gcws (grapheme-cluster-widths cs)]
     (if (some #{-1} gcws)

--- a/src/wcwidth/api.clj
+++ b/src/wcwidth/api.clj
@@ -63,7 +63,7 @@
   (when cs
     (sequence (.toArray (.codePoints cs)))))
 
-(defn ^:deprecated string-to-code-points
+(defn ^:deprecated ^:no-doc string-to-code-points
   "Deprecated. Use [[string->code-points]] instead."
   [s]
   (string->code-points s))

--- a/src/wcwidth/break_iterator_icu4j.clj
+++ b/src/wcwidth/break_iterator_icu4j.clj
@@ -10,6 +10,7 @@
 
 (in-ns 'wcwidth.api)
 
+
 (def grapheme-clusters-impl
   "Which implementation is in use for finding grapheme clusters?  A keyword
   with one of these values:
@@ -18,10 +19,11 @@
   * `:jdk`"
   :icu4j)
 
+
 (defn grapheme-clusters
   "Returns the [Unicode grapheme clusters](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)
   (what we tend to think of as \"characters\") in `cs` (a `CharSequence`) as a
-  sequence of `String`s, or `nil` when `s` is `nil`.
+  sequence of `String`s, or `nil` when `cs` is `nil`.
 
   Notes:
 

--- a/src/wcwidth/break_iterator_jdk.clj
+++ b/src/wcwidth/break_iterator_jdk.clj
@@ -23,7 +23,7 @@
 (defn grapheme-clusters
   "Returns the [Unicode grapheme clusters](https://www.unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)
   (what we tend to think of as \"characters\") in `cs` (a `CharSequence`) as a
-  sequence of `String`s, or `nil` when `s` is `nil`.
+  sequence of `String`s, or `nil` when `cs` is `nil`.
 
   Notes:
 


### PR DESCRIPTION
com.github.pmonks/clj-wcwidth release 1.0.145. See commit log for details of what's included in this release.